### PR TITLE
Add PaginatedResult Interface

### DIFF
--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -36,4 +36,28 @@ export interface User {
     updated_at: string;
 }
 
+export interface PaginatedResult<T> {
+  data: T[];
+  links: {
+    first: string;
+    last: string;
+    next?: string;
+    prev?: string;
+  };
+  meta: {
+    current_page: number;
+    from?: number;
+    last_page: number;
+    links: {
+      active: boolean;
+      label: string;
+      url?: string;
+    }[];
+    path: string;
+    per_page: number;
+    to?: number;
+    total: number;
+  };
+};
+
 export type BreadcrumbItemType = BreadcrumbItem;


### PR DESCRIPTION
Adding a `PaginatedResult` interface with generics to allow for better typed pagination between Laravel and Inertia/Vue